### PR TITLE
try to parse job using JSON and then YAML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development do
   gem 'redcarpet', '~> 1'
   gem 'github-markup'
   gem 'yard'
+  gem 'json'
 end


### PR DESCRIPTION
I would like beaneater to parse valid JSON, not just valid YAML, so I added a few lines to try to parse jobs as JSON first.
