### PR TITLE
Tube names with non-word boundaries incorrectly parsed

### DIFF
--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -111,7 +111,7 @@ module Beaneater
     def parse_response(cmd, res)
       res_lines = res.split(/\r?\n/)
       status = res_lines.first
-      status, id = status.scan(/\w+/)
+      status, id = status.split(/\s/)
       raise UnexpectedResponse.from_status(status, cmd) if UnexpectedResponse::ERROR_STATES.include?(status)
       raw_body = res_lines[1..-1].join("\n")
       body = ['FOUND', 'RESERVED'].include?(status) ? config.job_parser.call(raw_body) : YAML.load(raw_body)


### PR DESCRIPTION
Tube names can contain more then word-boundaries (\w): https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt#L13

Before:

```
>> b.tubes.use "some-tube"
=> "some-tube"

>> b.tubes.used
=> #<Beaneater::Tube name="some"> # Err
```

After:

```
>> b.tubes.use "some-tube"
=> "some-tube"

>> b.tubes.used
=> #<Beaneater::Tube name="some-tube">
```

116 tests, 212 assertions, 0 failures, 0 errors, 0 skips
