### PR TITLE
Change prompt regexp for telnet client

### DIFF
--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -91,7 +91,7 @@ module Beaneater
     def establish_connection
       @match = address.split(':')
       @host, @port = @match[0], Integer(@match[1] || DEFAULT_PORT)
-      Net::Telnet.new('Host' => @host, "Port" => @port, "Prompt" => /\n/)
+      Net::Telnet.new('Host' => @host, "Port" => @port, "Prompt" => /\n\z/)
     rescue Errno::ECONNREFUSED => e
       raise NotConnected, "Could not connect to '#{@host}:#{@port}'"
     rescue Exception => ex

--- a/test/pool_test.rb
+++ b/test/pool_test.rb
@@ -19,10 +19,10 @@ describe Beaneater::Pool do
         @host_num = '1.1.1.1:11303'
         @hosts = [@host_string_port, @host_num_port, @host_string, @host_num]
 
-        Net::Telnet.expects(:new).with('Host' => 'localhost', "Port" => 11301, "Prompt" => /\n/).once
-        Net::Telnet.expects(:new).with('Host' => '127.0.0.1', "Port" => 11302, "Prompt" => /\n/).once
-        Net::Telnet.expects(:new).with('Host' => 'host.local', "Port" => 11300, "Prompt" => /\n/).once
-        Net::Telnet.expects(:new).with('Host' => '1.1.1.1', "Port" => 11303, "Prompt" => /\n/).once
+        Net::Telnet.expects(:new).with('Host' => 'localhost', "Port" => 11301, "Prompt" => /\n\z/).once
+        Net::Telnet.expects(:new).with('Host' => '127.0.0.1', "Port" => 11302, "Prompt" => /\n\z/).once
+        Net::Telnet.expects(:new).with('Host' => 'host.local', "Port" => 11300, "Prompt" => /\n\z/).once
+        Net::Telnet.expects(:new).with('Host' => '1.1.1.1', "Port" => 11303, "Prompt" => /\n\z/).once
 
         @bp = Beaneater::Pool.new(@hosts)
       end

--- a/test/prompt_regexp_test.rb
+++ b/test/prompt_regexp_test.rb
@@ -1,0 +1,44 @@
+# test/prompt_regexp_test.rb
+
+require File.expand_path('../test_helper', __FILE__)
+require 'socket'
+
+describe "Prompt regexp for telnet client" do
+  before do
+    @fake_port = 11301
+    @tube_name = 'tube.to.test'
+
+    @fake_server = fork do 
+      server = TCPServer.new(@fake_port)
+      loop do
+        client = server.accept
+        while line = client.gets
+          case line
+          when /list-tubes-watched/i
+            client.puts "OK 11\n---\n- #{@tube_name}\n"
+          when /watch #{@tube_name}/i
+            client.puts 'WATCHING 1'
+          when /reserve/i
+            client.puts 'RESERVED 17 17'
+            client.print '[first part]'
+            # Emulate network delay
+            sleep 0.5
+            client.puts '[second part]'
+          else
+            client.puts 'ERROR'
+          end
+        end
+      end
+    end
+  end
+
+  it 'should reserve job with full body' do
+    pool = Beaneater::Pool.new("localhost:#{@fake_port}")
+    job = pool.tubes[@tube_name].reserve
+    assert_equal '[first part][second part]', job.body
+  end
+
+  after do
+    Process.kill("KILL", @fake_server)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 $:.unshift File.expand_path("../../lib")
 require 'beaneater'
 require 'fakeweb'
-require 'mocha'
+require 'mocha/setup'
 require 'json'
 
 FakeWeb.allow_net_connect = false


### PR DESCRIPTION
Net::Telnet doesn't process beanstalkd response correctly with /\n/ (without end-of-line modifier) regexp as a prompt. See https://github.com/ruby/ruby/blob/trunk/lib/net/telnet.rb#L555
And it causes some errors. We receive broken responses. Test attached
