### PR TITLE
Remove unused development dependency on fakeweb

### DIFF
--- a/beaneater.gemspec
+++ b/beaneater.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'minitest', "~> 4.1.0"
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'mocha'
-  gem.add_development_dependency 'fakeweb'
   gem.add_development_dependency 'term-ansicolor'
   gem.add_development_dependency 'json'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,11 +3,9 @@ require 'rubygems'
 require 'minitest/autorun'
 $:.unshift File.expand_path("../../lib")
 require 'beaneater'
-require 'fakeweb'
+require 'timeout'
 require 'mocha'
 require 'json'
-
-FakeWeb.allow_net_connect = false
 
 class MiniTest::Unit::TestCase
 


### PR DESCRIPTION
Hello, fakeweb is not used anywhere so it could be dropped.
