### PR TITLE
When using `safe_transmit`, wrap unexpected exceptions that are not alre...

### DIFF
--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -46,16 +46,15 @@ module Beaneater
     #   @conn.transmit('bury 123')
     #
     def transmit(command, options={})
-      @mutex.lock
-      if connection
-        command = command.force_encoding('ASCII-8BIT') if command.respond_to?(:force_encoding)
-        connection.write(command+"\r\n")
-        parse_response(command, connection.gets)
-      else # no connection
-        raise NotConnected, "Connection to beanstalk '#{@host}:#{@port}' is closed!" unless connection
+      @mutex.synchronize do
+        if connection
+          command = command.force_encoding('ASCII-8BIT') if command.respond_to?(:force_encoding)
+          connection.write(command+"\r\n")
+          parse_response(command, connection.gets)
+        else # no connection
+          raise NotConnected, "Connection to beanstalk '#{@host}:#{@port}' is closed!" unless connection
+        end
       end
-    ensure
-      @mutex.unlock
     end
 
     # Close connection with beanstalkd server.

--- a/lib/beaneater/errors.rb
+++ b/lib/beaneater/errors.rb
@@ -6,6 +6,21 @@ module Beaneater
   # Raises when a job has not been reserved properly.
   class JobNotReserved < RuntimeError; end
 
+  # Exception raised when something unexpected occured inside beaneater
+  class UnexpectedException < RuntimeError
+    attr_reader :cause
+
+    def initialize(cause)
+      @cause = cause
+
+      super("Unexpected exception: #{cause}")
+    end
+
+    def backtrace
+      (cause.backtrace || []).concat(super || [])
+    end
+  end
+
   # Abstract class for errors that occur when a command does not complete successfully.
   class UnexpectedResponse < RuntimeError
     # Set of status states that are considered errors

--- a/lib/beaneater/pool.rb
+++ b/lib/beaneater/pool.rb
@@ -148,6 +148,9 @@ module Beaneater
         else # finished retrying, fail out
           ex.is_a?(DrainingError) ? raise(ex) : raise(NotConnected, "Could not connect!")
         end
+      rescue Exception => ex
+        raise ex if ex.is_a?(UnexpectedResponse)
+        raise UnexpectedException, ex
       end
     end # transmit_call
 

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -30,4 +30,25 @@ describe "Beaneater::Errors" do
     assert_equal 'reserve 0', @klazz.cmd
     assert_equal 'EXPECTED_CRLF', @klazz.status
   end
+
+
+  describe "UnexpectedException" do
+    let(:cause) { Exception.new("Dummy Exception") }
+    let(:subject) { Beaneater::UnexpectedException.new(cause) }
+
+    it "saves the exception that caused UnexpectedException" do
+      assert_same subject.cause, cause
+    end
+
+    it "builds a relevant message using the cause Exception" do
+      assert_equal "Unexpected exception: Dummy Exception", subject.message
+    end
+
+    it "changes the backtrace to include the cause's backtrace" do
+      cause.set_backtrace(["1", "2", "3"])
+      subject.set_backtrace(["4", "5", "6"])
+
+      assert_equal ["1", "2", "3", "4", "5", "6"], subject.backtrace
+    end
+  end
 end

--- a/test/pool_test.rb
+++ b/test/pool_test.rb
@@ -164,6 +164,11 @@ describe Beaneater::Pool do
       TCPSocket.any_instance.expects(:gets).once.returns('DEADLINE_SOON')
       assert_raises(Beaneater::DeadlineSoonError) { @bp.transmit_to_rand 'expecting deadline' }
     end
+
+    it "raises UnexpectedException when any Exception occurs inside the block" do
+      invalid_command = nil
+      assert_raises(Beaneater::UnexpectedException) { @bp.transmit_to_rand(invalid_command) }
+    end
   end
 
   describe "for #close" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'minitest/autorun'
 $:.unshift File.expand_path("../../lib")
 require 'beaneater'
 require 'timeout'
-require 'mocha'
+require 'mocha/setup'
 require 'json'
 
 class MiniTest::Unit::TestCase


### PR DESCRIPTION
...ady wrapped in `Beaneater::UnexpectedResponse` and raise the wrapped exception.

This allows applications using beaneater to catch these exceptions and
act accordingly instead of raising exceptions comming from beaneater.

We noticed this problem when shutting down beanstalk. beaneater raises
a `NoMethodError` instead of an exception that can be easily rescued
in our system.
