### PR TITLE
Convert version to float for version compare

### DIFF
--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -139,7 +139,7 @@ describe Beaneater::Job do
       assert_equal 'foo touch', job.body
       job.bury
       assert_equal 1, @tube.stats.current_jobs_buried
-      if @pool.stats.version > 1.7
+      if @pool.stats.version.to_f > 1.7
         job.kick
         assert_equal 0, @tube.stats.current_jobs_buried
         assert_equal 1, @tube.stats.current_jobs_ready


### PR DESCRIPTION
This pull request fixes a test error I'm seeing in job_test.rb, specifically, "should be toucheable" in the "for #kick" context. Here's the output from rake for the failed test

```
Beaneater::Job::for #kick#test_0001_should be toucheable:
ArgumentError: comparison of String with Float failed
    /src/beaneater/test/job_test.rb:142:in `>'
    /src/beaneater/test/job_test.rb:142:in `block (3 levels) in <top (required)>'
```
