### PR TITLE
Wait for fake beanstalk tcp server before running test

### DIFF
--- a/test/prompt_regexp_test.rb
+++ b/test/prompt_regexp_test.rb
@@ -31,11 +31,22 @@ describe "Reading from socket client" do
         end
       end
     end
+
+    slept = 0
+    while @pool.nil?
+      begin
+        @pool = Beaneater::Pool.new("localhost:#{@fake_port}")
+      rescue Beaneater::NotConnected
+        raise 'Could not connect to fake beanstalkd server' if slept > 1
+        sleep 0.1
+        slept += 0.1
+      end
+    end
+
   end
 
   it 'should reserve job with full body' do
-    pool = Beaneater::Pool.new("localhost:#{@fake_port}")
-    job = pool.tubes[@tube_name].reserve
+    job = @pool.tubes[@tube_name].reserve
     assert_equal '[first part][second part]', job.body
   end
 


### PR DESCRIPTION
This pull request fixes a test error I'm seeing due to a race condition where the tests in prompt_regexp_test.rb begin before the fake beanstalkd TCP server is running. Here is the output from rake when the test fails:

```
  1) Error:
Reading from socket client#test_0001_should reserve job with full body:
Beaneater::NotConnected: Could not connect to 'localhost:11301'
    /src/beaneater/lib/beaneater/connection.rb:96:in `rescue in establish_connection'
    /src/beaneater/lib/beaneater/connection.rb:92:in `establish_connection'
    /src/beaneater/lib/beaneater/connection.rb:36:in `initialize'
    /src/beaneater/lib/beaneater/pool.rb:25:in `new'
    /src/beaneater/lib/beaneater/pool.rb:25:in `block in initialize'
    /src/beaneater/lib/beaneater/pool.rb:25:in `map'
    /src/beaneater/lib/beaneater/pool.rb:25:in `initialize'
    /src/beaneater/test/prompt_regexp_test.rb:37:in `new'
    /src/beaneater/test/prompt_regexp_test.rb:37:in `block (2 levels) in <top (required)>'
```
