### PR TITLE
Make test:full the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,3 +29,5 @@ YARD::Rake::YardocTask.new do |t|
   t.files   = ['lib/beaneater/**/*.rb']
   t.options = []
 end
+
+task :default => 'test:full'


### PR DESCRIPTION
Minor change to make test:full the default rake task.

Just because this default makes sense to me, doesn't mean it actually makes sense, so I wanted to verify this change with others before merging.
