### PR TITLE
Reduce sleep in thread safe tests by 87.5%

### DIFF
--- a/test/beaneater_test.rb
+++ b/test/beaneater_test.rb
@@ -23,12 +23,12 @@ describe "beanstalk-client" do
       # A: put one
       a = Thread.new do
         tube_one = @beanstalk.tubes.find('one')
-        sleep 4
+        sleep 0.5
         tube_one.put('one')
       end
 
       b = Thread.new do
-        sleep 1
+        sleep 0.125
         tube_two = @beanstalk.tubes.find('two')
         tube_two.put('two')
       end
@@ -52,13 +52,13 @@ describe "beanstalk-client" do
     before do
       a = Thread.new do
         tube_one = @beanstalk.tubes.find('one')
-        sleep 4
+        sleep 0.5
         tube_one.put('one')
       end
 
       b = Thread.new do
         tube_two = @beanstalk.tubes.find('two')
-        sleep 1
+        sleep 0.125
         tube_two.put('two')
       end
 


### PR DESCRIPTION
This change reduces the sleeps in test/beaneater_test.rb by 87.5%. This makes the full test suite about 7-8x faster.

I'm not sure if there is a reason the sleeps are set the way they are (possibly there's an issue with race conditions and the longer sleeps are needed to ensure consistency?), but I ran the thread safe tests about 50 times with the reduced sleep cycles and encountered no failures.

It may even be possible to reduce the sleeps further, but getting the test suite under 5 seconds (at least on my machine) is sufficient for me.
