### PR TITLE
Fix confusion when beanstalkd doesn't contain body

### DIFF
--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -123,8 +123,9 @@ module Beaneater
         raise ExpectedCrlfError.new('EXPECTED_CRLF', cmd) if crlf != "\r\n"
       end
       id = body_values[1]
-      response = { :status => status, :body => body }
+      response = { :status => status }
       response[:id] = id if id
+      response[:body] = body if body
       response[:connection] = self
       response
     end


### PR DESCRIPTION
When I put new job with body:

```
irb(main):011:0> job_body = "example"
irb(main):012:0> beaneater.tubes['default'].put(job_body)
=> {:status=>"INSERTED", :body=>nil, :id=>"113", :connection=>#<Beaneater::Connection host="localhost" port=11300>}
```

I received hash with `:body=>nil` and it confused me a bit because I sent body `"example"`. Maybe better hide body key if answer from beanstalkd doesn't imply that?
