### PR TITLE
Remove warnings

### DIFF
--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -92,7 +92,7 @@ module Beaneater
       @match = address.split(':')
       @host, @port = @match[0], Integer(@match[1] || DEFAULT_PORT)
       TCPSocket.new @host, @port
-    rescue Errno::ECONNREFUSED => e
+    rescue Errno::ECONNREFUSED
       raise NotConnected, "Could not connect to '#{@host}:#{@port}'"
     rescue Exception => ex
       raise NotConnected, "#{ex.class}: #{ex}"

--- a/lib/beaneater/job/collection.rb
+++ b/lib/beaneater/job/collection.rb
@@ -32,7 +32,7 @@ module Beaneater
     def find(id)
       res = transmit_until_res("peek #{id}", :status => "FOUND")
       Job.new(res)
-    rescue Beaneater::NotFoundError => ex
+    rescue Beaneater::NotFoundError
       nil
     end
     alias_method :peek, :find
@@ -49,7 +49,7 @@ module Beaneater
     def find_all(id)
       res = transmit_to_all("peek #{id}")
       res.compact.map { |r| Job.new(r) }
-    rescue Beaneater::NotFoundError => ex
+    rescue Beaneater::NotFoundError
       []
     end
 
@@ -103,7 +103,7 @@ module Beaneater
           break
         rescue Beaneater::JobNotReserved, Beaneater::NotFoundError, Beaneater::TimedOutError
           retry
-        rescue StandardError => e # handles unspecified errors
+        rescue StandardError # handles unspecified errors
           job.bury if job
         ensure # bury if still reserved
           job.bury if job && job.exists? && job.reserved?

--- a/lib/beaneater/tube/collection.rb
+++ b/lib/beaneater/tube/collection.rb
@@ -133,7 +133,7 @@ module Beaneater
     #
     def use(tube)
       return tube if @last_used == tube
-      res = transmit_to_all("use #{tube}")
+      transmit_to_all("use #{tube}")
       @last_used = tube
     rescue BadFormatError
       raise InvalidTubeName, "Tube cannot be named '#{tube}'"

--- a/lib/beaneater/tube/record.rb
+++ b/lib/beaneater/tube/record.rb
@@ -53,7 +53,7 @@ module Beaneater
         res = transmit_until_res "peek-#{state}", :status => "FOUND"
         Job.new(res)
       end
-    rescue Beaneater::NotFoundError => ex
+    rescue Beaneater::NotFoundError
       # Return nil if not found
       nil
     end
@@ -161,6 +161,5 @@ module Beaneater
     def config
       Beaneater.configuration
     end
-
   end # Tube
 end # Beaneater


### PR DESCRIPTION
```
/Users/trsw/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/beaneater-0.3.3/lib/beaneater/connection.rb:95: warning: assigned but unused variable - e
/Users/trsw/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/beaneater-0.3.3/lib/beaneater/tube/record.rb:56: warning: assigned but unused variable - ex
/Users/trsw/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/beaneater-0.3.3/lib/beaneater/tube/collection.rb:136: warning: assigned but unused variable - res
/Users/trsw/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/beaneater-0.3.3/lib/beaneater/job/collection.rb:35: warning: assigned but unused variable - ex
/Users/trsw/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/beaneater-0.3.3/lib/beaneater/job/collection.rb:52: warning: assigned but unused variable - ex
/Users/trsw/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/beaneater-0.3.3/lib/beaneater/job/collection.rb:106: warning: assigned but unused variable - e
```
