### PR TITLE
Custom job serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Beaneater.configure do |config|
   # config.default_put_pri     = 65536
   # config.default_put_ttr     = 120
   # config.job_parser          = lambda { |body| body }
+  # config.job_serializer      = lambda { |body| body }
   # config.beanstalkd_url      = ['localhost:11300']
 end
 ```
@@ -246,6 +247,16 @@ Beanstalkd can only stores strings as job bodies, but you can easily encode your
 
 ```ruby
 @tube.put({:foo => 'bar'}.to_json)
+```
+
+Moreover, you can provide a default job serializer by setting the corresponding configuration
+option (`job_serializer`), in order to apply the encoding on each job body which
+is going to be send using the `put` command. For example, to encode a ruby object to JSON format:
+
+```ruby
+Beaneater.configure do |config|
+  config.job_serializer = lambda { |body| JSON.dump(body) }
+end
 ```
 
 Each job has various metadata associated such as `priority`, `delay`, and `ttr` which can be

--- a/lib/beaneater/configuration.rb
+++ b/lib/beaneater/configuration.rb
@@ -4,6 +4,7 @@ module Beaneater
     attr_accessor :default_put_pri     # default priority value to put a job
     attr_accessor :default_put_ttr     # default ttr value to put a job
     attr_accessor :job_parser          # default job_parser to parse job body
+    attr_accessor :job_serializer      # default serializer for job body
     attr_accessor :beanstalkd_url      # default beanstalkd url
 
     def initialize
@@ -11,6 +12,7 @@ module Beaneater
       @default_put_pri     = 65536
       @default_put_ttr     = 120
       @job_parser          = lambda { |body| body }
+      @job_serializer      = lambda { |body| body }
       @beanstalkd_url      = nil
     end
   end # Configuration

--- a/lib/beaneater/tube/record.rb
+++ b/lib/beaneater/tube/record.rb
@@ -33,10 +33,11 @@ module Beaneater
     # @api public
     def put(body, options={})
       safe_use do
+        serialized_body = config.job_serializer.call(body)
         options = { :pri => config.default_put_pri, :delay => config.default_put_delay,
                     :ttr => config.default_put_ttr }.merge(options)
-        cmd_options = "#{options[:pri]} #{options[:delay]} #{options[:ttr]} #{body.bytesize}"
-        transmit_to_rand("put #{cmd_options}\r\n#{body}")
+        cmd_options = "#{options[:pri]} #{options[:delay]} #{options[:ttr]} #{serialized_body.bytesize}"
+        transmit_to_rand("put #{cmd_options}\r\n#{serialized_body}")
       end
     end
 

--- a/test/tube_test.rb
+++ b/test/tube_test.rb
@@ -40,8 +40,15 @@ describe Beaneater::Tube do
       assert_raises(Beaneater::DrainingError) { @tube.put "bar put #{@time}" }
     end
 
+    it "should support custom serializer" do
+      Beaneater.configure.job_serializer = lambda { |b| JSON.dump(b) }
+      @tube.put({ foo: "bar"})
+      assert_equal '{"foo":"bar"}', @tube.peek(:ready).body
+    end
+
     after do
       Beaneater::Connection.any_instance.unstub(:transmit)
+      Beaneater.configure.job_serializer = lambda { |b| b }
     end
   end # put
 


### PR DESCRIPTION
Provides a way to add serialization on the payload (body) of `put` command.