### PR TITLE
Made tubes an enumerable

### DIFF
--- a/lib/beaneater/tube/collection.rb
+++ b/lib/beaneater/tube/collection.rb
@@ -1,6 +1,7 @@
 module Beaneater
   # Represents collection of tube related commands.
   class Tubes < PoolCommand
+    include Enumerable
 
     # Creates new tubes instance.
     #
@@ -56,6 +57,17 @@ module Beaneater
     # @api public
     def all
       transmit_to_all('list-tubes', :merge => true)[:body].map { |tube_name| Tube.new(self.pool, tube_name) }
+    end
+
+    # Calls the given block once for each known beanstalk tube, passing that element as a parameter.
+    #
+    # @return An Enumerator is returned if no block is given.
+    # @example
+    #   @pool.tubes.each {|t| puts t.name}
+    #
+    # @api public
+    def each
+      block_given? ? all.each(&Proc.new) : all.each
     end
 
     # List of watched beanstalk tubes.

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -18,7 +18,12 @@ describe Beaneater::Connection do
 
     it "should init connection" do
       assert_kind_of TCPSocket, @bc.connection
-      assert_equal '127.0.0.1', @bc.connection.peeraddr[3]
+      if @bc.connection.peeraddr[0] == 'AF_INET'
+        assert_equal '127.0.0.1', @bc.connection.peeraddr[3]
+      else
+        assert_equal 'AF_INET6', @bc.connection.peeraddr[0]
+        assert_equal '::1', @bc.connection.peeraddr[3]
+      end
       assert_equal 11300, @bc.connection.peeraddr[1]
     end
 

--- a/test/tubes_test.rb
+++ b/test/tubes_test.rb
@@ -60,6 +60,20 @@ describe Beaneater::Tubes do
     end
   end # all
 
+  describe "for Enumerable" do
+    before do
+      @pool = Beaneater::Pool.new(['localhost'])
+      @pool.tubes.find('foo').put 'bar'
+      @pool.tubes.find('bar').put 'foo'
+    end
+
+    it 'should map tubes' do
+      ['default', 'foo', 'bar'].each do |t|
+        assert @pool.tubes.map(&:name).include?(t)
+      end
+    end
+  end
+
   describe "for #used" do
     before do
       @pool = Beaneater::Pool.new(['localhost'])


### PR DESCRIPTION
Simple change to enable the use of `@pool.tubes` as an enumerable directly.

Example:

```ruby
@pool = Beaneater::Pool.new(['localhost'])
@pool.tubes.map(&:name) # => ['default', 'foo', 'bar']

@pool.tubes.each do |tube|
  tube.stats
  # [..]
end
```

---

The "Connection test should init connection" would not pass on my computer (archlinux 64bits, ruby 2.0.0-p598), so I fixed the test in case `Net::IPSocket#peeraddr` returns an IPv6 address.