### PR TITLE
Added StatStruct#to_h

### DIFF
--- a/lib/beaneater/stats/stat_struct.rb
+++ b/lib/beaneater/stats/stat_struct.rb
@@ -35,5 +35,11 @@ module Beaneater
     def keys
       @hash.keys.map { |k| k.to_s }
     end
+
+    # Returns the initialization hash
+    #
+    def to_h
+      @hash
+    end
   end # StatStruct
 end # Beaneater

--- a/test/stat_struct_test.rb
+++ b/test/stat_struct_test.rb
@@ -38,4 +38,14 @@ describe Beaneater::StatStruct do
       assert_equal ['foo', 'bar', 'baz', 'under_score'].sort, @struct.keys.sort
     end
   end # keys
+
+  describe "for #to_h" do
+    it "should return 4 keys / values" do
+      assert_equal 4, @struct.to_h.size
+    end
+
+    it "should return expect hash" do
+      assert_equal [['foo', 'bar'], ['bar', 'baz'], ['baz', 'foo'], ['under_score', 'demo']].sort, @struct.to_h.sort
+    end
+  end # to_h
 end # Beaneater::StatStruct


### PR DESCRIPTION
I wanted to access the StatStruct data in another project, and found that I have to do:

```ruby
stats = job.stats
Hash[stats.keys.map{|k| [k, stats[k]]}]
# Or worse, using protected API
job.send(:transmit, "stats-job #{job.id}")[:body]
```

So I simply implemented `StatStruct#to_h`