### PR TITLE
'clear' behavior was failing unexpectedly during operation

### DIFF
--- a/lib/beaneater/tube/record.rb
+++ b/lib/beaneater/tube/record.rb
@@ -133,11 +133,15 @@ class Beaneater
       client.tubes.watch!(self.name)
       %w(delayed buried ready).each do |state|
         while job = self.peek(state.to_sym)
-          job.delete
+          begin
+            job.delete
+          rescue Beaneater::UnexpectedResponse, Beaneater::NotFoundError
+            # swallow any issues
+          end
         end
       end
       client.tubes.ignore(name)
-    rescue Beaneater::UnexpectedResponse
+    rescue Beaneater::NotIgnoredError
       # swallow any issues
     end
 


### PR DESCRIPTION
Fixed by swallowing issues during delete as well, and specifically swallow the NotIgnoredError in the method scope.