### PR TITLE
Fix last_used tube not stored.

### DIFF
--- a/lib/beaneater/tube/collection.rb
+++ b/lib/beaneater/tube/collection.rb
@@ -175,7 +175,7 @@ class Beaneater
     def use(tube)
       return tube if last_used == tube
       transmit("use #{tube}")
-      last_used = tube
+      self.last_used = tube
     rescue BadFormatError
       raise InvalidTubeName, "Tube cannot be named '#{tube}'"
     end


### PR DESCRIPTION
`beanseater.tubes.last_used` never gets updated due syntax issue.

```
+irb(main):001:0> require "beaneater"
=> true
+irb(main):002:0> beaneater = Beaneater.new("127.0.0.1:11300")
=> #<Beaneater:0x00005642c5a303f0 @connection=#<Beaneater::Connection host="127.0.0.1" port=11300>>
+irb(main):003:0> beaneater.tubes.use("x")
=> "x"
+irb(main):004:0> beaneater.tubes.last_used
=> "default"
+irb(main):005:0> 
```