### PR TITLE
Fix deprecation warning in ruby 2.7

### DIFF
--- a/lib/beaneater/tube/collection.rb
+++ b/lib/beaneater/tube/collection.rb
@@ -88,8 +88,8 @@ class Beaneater
     #   @pool.tubes.each {|t| puts t.name}
     #
     # @api public
-    def each
-      block_given? ? all.each(&Proc.new) : all.each
+    def each(&block)
+      all.each(&block)
     end
 
     # List of watched beanstalk tubes.


### PR DESCRIPTION
Using Proc.new to capture block is deprecated in ruby 2.7, produces following warning:
```
gems/beaneater-0ac62400d228/lib/beaneater/tube/collection.rb:92: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```

See also:
https://docs.ruby-lang.org/en/master/doc/NEWS-2_7_0.html#label-proc-2Flambda+without+block+is+deprecated