### PR TITLE
Fix beaneater watches wrong tube after silent reconnect

### DIFF
--- a/lib/beaneater/tube/collection.rb
+++ b/lib/beaneater/tube/collection.rb
@@ -29,8 +29,8 @@ class Beaneater
     # Delegates transmit to the connection object.
     #
     # @see Beaneater::Connection#transmit
-    def transmit(command, options={})
-      client.connection.transmit(command, options)
+    def transmit(command, **options)
+      client.connection.transmit(command, **options)
     end
 
     # Finds the specified beanstalk tube.

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -96,6 +96,24 @@ describe Beaneater::Connection do
 
       assert_raises(Beaneater::NotConnected) { @bc.transmit "delete 56\r\n" }
     end
+
+    it "tubes_watched are restored after reconnect" do
+      client = Beaneater.new('127.0.0.1:11300')
+      client.tubes.watch! "another"
+
+      TCPSocket.prepend Module.new {
+        def readline
+          if !$called
+            $called = true
+            raise EOFError
+          end
+
+          super
+        end
+      }
+
+      assert_equal %w[another], client.tubes.watched.map(&:name)
+    end
   end # transmit
 
   describe 'for #close' do


### PR DESCRIPTION
Due to the way Beaneater::Connection#transmit handles its parameters,
`_initialize_tubes` was never called.

This causes a client indefinitely blocked by `reserve` when connection lost.
Basically, if you're not using `default` tube, your worker will stop working when you restart beanstalkd.