### PR TITLE
Support Ruby 3 keyword arguments

### DIFF
--- a/lib/beaneater/job/collection.rb
+++ b/lib/beaneater/job/collection.rb
@@ -37,7 +37,7 @@ class Beaneater
     #
     # @see Beaneater::Connection#transmit
     def transmit(command, options={})
-      client.connection.transmit(command, options)
+      client.connection.transmit(command, **options)
     end
 
     # Peek (or find) job by id from beanstalkd.

--- a/lib/beaneater/tube/record.rb
+++ b/lib/beaneater/tube/record.rb
@@ -25,7 +25,7 @@ class Beaneater
     #
     # @see Beaneater::Connection#transmit
     def transmit(command, options={})
-      client.connection.transmit(command, options)
+      client.connection.transmit(command, **options)
     end
 
     # Inserts job with specified body onto tube.


### PR DESCRIPTION
This pull request addresses the following `ArgumentError: wrong number of arguments (given 2, expected 1)` errors.


```ruby
$ bundle exec ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [x86_64-linux]
$ bundle exec ruby -Itest test/jobs_test.rb -n /test_0002_should/
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Mocha deprecation warning at /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:10:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
Run options: -n /test_0002_should/ --seed 13236

# Running tests:

EEE

Finished tests in 0.006310s, 475.4275 tests/s, 158.4758 assertions/s.

  1) Error:
test_0002_should return job using peek(Beaneater::Jobs::for #find):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:54:in `block in put'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:44:in `put'
    test/jobs_test.rb:15:in `block (3 levels) in <main>'

  2) Error:
test_0002_should return job using peek(Beaneater::Jobs::for #find):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:68:in `block in peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:67:in `peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:135:in `block in clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:38:in `block in flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:44:in `teardown'

  3) Error:
test_0002_should store block for 'tube'(Beaneater::Jobs::for #register!):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:68:in `block in peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:67:in `peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:135:in `block in clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:38:in `block in flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:44:in `teardown'

  4) Error:
test_0002_should clear successful_jobs(Beaneater::Jobs::for process!):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:68:in `block in peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:67:in `peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:135:in `block in clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:26:in `block in cleanup_tubes!'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:25:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:25:in `cleanup_tubes!'
    test/jobs_test.rb:75:in `block (3 levels) in <main>'

  5) Error:
test_0002_should clear successful_jobs(Beaneater::Jobs::for process!):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:68:in `block in peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:67:in `peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:135:in `block in clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:38:in `block in flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:44:in `teardown'

3 tests, 1 assertions, 0 failures, 5 errors, 0 skips
[Coveralls] Outside the CI environment, not sending data.
$
```

```ruby
$ bundle exec ruby -Itest test/jobs_test.rb -n /test_0004_should/
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
Mocha deprecation warning at /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:10:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
Run options: -n /test_0004_should/ --seed 1074

# Running tests:

EE

Finished tests in 0.004602s, 434.6233 tests/s, 0.0000 assertions/s.

  1) Error:
test_0004_should return nil for invalid id(Beaneater::Jobs::for #find):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:54:in `block in put'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:44:in `put'
    test/jobs_test.rb:15:in `block (3 levels) in <main>'

  2) Error:
test_0004_should return nil for invalid id(Beaneater::Jobs::for #find):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:68:in `block in peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:67:in `peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:135:in `block in clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:38:in `block in flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:44:in `teardown'

  3) Error:
test_0004_should bury unexpected exception(Beaneater::Jobs::for process!):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:68:in `block in peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:67:in `peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:135:in `block in clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:26:in `block in cleanup_tubes!'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:25:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:25:in `cleanup_tubes!'
    test/jobs_test.rb:75:in `block (3 levels) in <main>'

  4) Error:
test_0004_should bury unexpected exception(Beaneater::Jobs::for process!):
ArgumentError: wrong number of arguments (given 2, expected 1)
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/connection.rb:72:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:28:in `transmit'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:68:in `block in peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:172:in `safe_use'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:67:in `peek'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:135:in `block in clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/lib/beaneater/tube/record.rb:134:in `clear'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:38:in `block in flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `each'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:37:in `flush_all'
    /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:44:in `teardown'

2 tests, 0 assertions, 0 failures, 4 errors, 0 skips
[Coveralls] Outside the CI environment, not sending data.
$
```