### PR TITLE
CI against Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
 before_install:
   - curl -L https://github.com/kr/beanstalkd/archive/v1.9.tar.gz | tar xz -C /tmp
   - cd /tmp/beanstalkd-1.9/


### PR DESCRIPTION
This pull request enables CI against Ruby 3.0.

Related to https://github.com/beanstalkd/beaneater/pull/80