### PR TITLE
Address `Mocha deprecation warning` since Mocha 1.10.0

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ $:.unshift File.expand_path("../../lib")
 require 'beaneater'
 require 'timeout'
 begin
-  require 'mocha/setup'
+  require 'mocha/minitest'
 rescue LoadError
   require 'mocha'
 end


### PR DESCRIPTION
This pull request addresses `Mocha deprecation warning` since Mocha 1.10.0.

```ruby
$ bundle exec rake test
... snip ...
Mocha deprecation warning at /home/yahonda/src/github.com/beanstalkd/beaneater/test/test_helper.rb:10:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
```