### PR TITLE
Work around YAML syntax issues

### DIFF
--- a/beaneater.gemspec
+++ b/beaneater.gemspec
@@ -17,9 +17,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-
-  gem.add_dependency 'psych', "~> 4.0"
-
   gem.add_development_dependency 'minitest', "~> 4.1.0"
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'mocha'

--- a/beaneater.gemspec
+++ b/beaneater.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+
+  gem.add_dependency 'psych', "~> 4.0"
+
   gem.add_development_dependency 'minitest', "~> 4.1.0"
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'mocha'

--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -150,7 +150,8 @@ class Beaneater
       if ['OK','FOUND', 'RESERVED'].include?(status)
         bytes_size = body_values[-1].to_i
         raw_body = connection.read(bytes_size)
-        body = status == 'OK' ? YAML.load(raw_body) : config.job_parser.call(raw_body)
+        psych_v4_valid_body = raw_body.gsub(/^(.*?): (.*)$/) { "#{$1}: #{$2.gsub(/[\:\-\~]/, '_')}" }
+        body = status == 'OK' ? YAML.load(psych_v4_valid_body) : config.job_parser.call(psych_v4_valid_body)
         crlf = connection.read(2) # \r\n
         raise ExpectedCrlfError.new('EXPECTED_CRLF', cmd) if crlf != "\r\n"
       end


### PR DESCRIPTION
# Problem

Ruby 3.1 introduces YAML 4, which in turn rejects the YAML generated by `beanstalkd` API responses. The result was YAML exceptions such as:

```
Psych::SyntaxError: (<unknown>): mapping values are not allowed in this context at line 51 column 33
```

# Cause

This arises because of unquoted values in the stats data from the daemon:

```yaml
os: Darwin Kernel Version 21.6.0: Mon Aug 22 20:17:10 PDT 2022; root:xnu-8020.140.49~2/RELEASE_X86_64
```

You will note spaces after colons, so this is clearly simply invalid and should've been escaped at source. Indeed, when I run `bundle exec rake test`, I get four test failures on current `master`:

```
  1) Error:
test_0001_should return yaml loaded response(Beaneater::Connection::for #transmit):
Psych::SyntaxError: (<unknown>): mapping values are not allowed in this context at line 51 column 33
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:455:in `parse'
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:455:in `parse_stream'
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:399:in `parse'
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:323:in `safe_load'
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:369:in `load'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:153:in `parse_response'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:80:in `block (2 levels) in transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:74:in `synchronize'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:74:in `block in transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:193:in `_with_retry'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:73:in `transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/test/connection_test.rb:49:in `block (3 levels) in <top (required)>'

  2) Error:
test_0001_should be toucheable(Beaneater::Job::for #kick):
Psych::SyntaxError: (<unknown>): mapping values are not allowed in this context at line 51 column 33
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:455:in `parse'
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:455:in `parse_stream'
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:399:in `parse'
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:323:in `safe_load'
    /Users/adh1003/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/psych-4.0.6/lib/psych.rb:369:in `load'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:153:in `parse_response'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:80:in `block (2 levels) in transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:74:in `synchronize'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:74:in `block in transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:193:in `_with_retry'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:73:in `transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/stats.rb:76:in `data'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/stats.rb:56:in `method_missing'
    /Users/adh1003/Documents/Work/RIP/beaneater/test/job_test.rb:142:in `block (3 levels) in <top (required)>'

  3) Error:
test_0001_should be toucheable(Beaneater::Job::for #kick):
NoMethodError: undefined method `map' for nil:NilClass

      transmit('list-tubes')[:body].map do |tube_name|
                                   ^^^^
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/tube/collection.rb:79:in `all'
    /Users/adh1003/Documents/Work/RIP/beaneater/test/test_helper.rb:37:in `flush_all'
    /Users/adh1003/Documents/Work/RIP/beaneater/test/test_helper.rb:44:in `teardown'

  4) Error:
test_0004_should return nil for invalid id(Beaneater::Jobs::for #find):
Beaneater::BadFormatError: Response failed with: BAD_FORMAT
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:148:in `parse_response'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:80:in `block (2 levels) in transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:74:in `synchronize'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:74:in `block in transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:193:in `_with_retry'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:73:in `transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/job/collection.rb:40:in `transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/job/collection.rb:54:in `find'
    /Users/adh1003/Documents/Work/RIP/beaneater/test/jobs_test.rb:32:in `block (3 levels) in <top (required)>'
```

# Fix

Since `beanstalkd` is generating bad YAML but it's not at this point practical or time-efficient to fix that, I just used `gsub` to change the in-flight data. It feels like a hack of course, but it appears to be a very effective one.

I still have a failing test, but that's just how `master` is on my machine - this PR does at least fix the other three bugs, when Psych 4 is present. Now all I get is:

```
  1) Error:
test_0004_should return nil for invalid id(Beaneater::Jobs::for #find):
Beaneater::BadFormatError: Response failed with: BAD_FORMAT
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:148:in `parse_response'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:80:in `block (2 levels) in transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:74:in `synchronize'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:74:in `block in transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:194:in `_with_retry'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/connection.rb:73:in `transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/job/collection.rb:40:in `transmit'
    /Users/adh1003/Documents/Work/RIP/beaneater/lib/beaneater/job/collection.rb:54:in `find'
    /Users/adh1003/Documents/Work/RIP/beaneater/test/jobs_test.rb:32:in `block (3 levels) in <top (required)>'
```

...and everything else passes.

# A closing note

The YAML from `beanstalkd` was never very well-formed and it is a bit of a mystery to me why they didn't just use JSON, but we are where we are. If it is possible to coerce `beanstalkd` to conversing in JSON instead then that would likely be a much safer route than using YAML, but that is a scope of change that's far greater than I can risk given how unfamiliar I am with this gem and with the `beanstalkd` communication protocol.