### PR TITLE
Fix YAML adjustment fumble I made in v1.1.2 which broke JSON job data

### DIFF
--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -150,8 +150,12 @@ class Beaneater
       if ['OK','FOUND', 'RESERVED'].include?(status)
         bytes_size = body_values[-1].to_i
         raw_body = connection.read(bytes_size)
-        psych_v4_valid_body = raw_body.gsub(/^(.*?): (.*)$/) { "#{$1}: #{$2.gsub(/[\:\-\~]/, '_')}" }
-        body = status == 'OK' ? YAML.load(psych_v4_valid_body) : config.job_parser.call(psych_v4_valid_body)
+        body = if status == 'OK'
+          psych_v4_valid_body = raw_body.gsub(/^(.*?): (.*)$/) { "#{$1}: #{$2.gsub(/[\:\-\~]/, '_')}" }
+          YAML.load(psych_v4_valid_body)
+        else
+          config.job_parser.call(raw_body)
+        end
         crlf = connection.read(2) # \r\n
         raise ExpectedCrlfError.new('EXPECTED_CRLF', cmd) if crlf != "\r\n"
       end

--- a/test/tube_test.rb
+++ b/test/tube_test.rb
@@ -89,9 +89,9 @@ describe Beaneater::Tube do
 
     it "should support custom parser" do
       Beaneater.configure.job_parser = lambda { |b| JSON.parse(b) }
-      json = '{"message":"hi"}'
+      json = '{"message": "hi: there! this: is a long message"}'
       @tube.put(json)
-      assert_equal 'hi', @tube.peek(:ready).body['message']
+      assert_equal 'hi: there! this: is a long message', @tube.peek(:ready).body['message']
     end
 
     after do


### PR DESCRIPTION
In reference to #86 and #87, I found an existing JSON test for jobs and added colons into the value to detect telltale behaviour from the bug I introduced in #86. Without fixes, this exhibited the problems reported in #87 with colons replaced by underscores inside JSON data. Once adjusted per the idea I mentioned in https://github.com/beanstalkd/beaneater/pull/86#issuecomment-1279429320, the updated test passed and the two that were fixed by 1.1.1 -> 1.1.2 continue to pass also.