### PR TITLE
Move broken build to GitHub Actions + Add Ruby 3.1 + Upgrade to Beanstalkd 1.13

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Build Status
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Make beaneater
+      run: make
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Daemonize beaneater
+      run: ./beanstalkd &
+    - name: Run tests
+      run: bundle exec rake test:full

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,16 +27,16 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download & Extract beanstalkd
-      run: curl -L https://github.com/beanstalkd/beanstalkd/archive/refs/tags/v1.13.tar.gz | tar xz -C beanstalkd
+      run: curl -L https://github.com/beanstalkd/beanstalkd/archive/refs/tags/v1.13.tar.gz | tar xz
     - name: Make beanstalkd
       run: make
-      working-directory: beanstalkd
+      working-directory: beanstalkd-1.13
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Daemonize beanstalkd
-      run: ./beanstalkd/beanstalkd &
+      run: ./beanstalkd-1.13/beanstalkd &
     - name: Run tests
       run: bundle exec rake test:full

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,14 +26,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Make beaneater
+    - name: Download & Extract beanstalkd
+      run: curl -L https://github.com/beanstalkd/beanstalkd/archive/refs/tags/v1.13.tar.gz | tar xz -C beanstalkd
+    - name: Make beanstalkd
       run: make
+      working-directory: beanstalkd
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Daemonize beaneater
-      run: ./beanstalkd &
+    - name: Daemonize beanstalkd
+      run: ./beanstalkd/beanstalkd &
     - name: Run tests
       run: bundle exec rake test:full

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Beaneater
-[![Build Status](https://secure.travis-ci.org/beanstalkd/beaneater.png)](http://travis-ci.org/beanstalkd/beaneater)
+![Build Status](https://github.com/beanstalkd/beaneater/actions/workflows/ruby.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/beanstalkd/beaneater/badge.png?branch=master)](https://coveralls.io/r/beanstalkd/beaneater)
 
 Beaneater is the best way to interact with beanstalkd from within Ruby.


### PR DESCRIPTION
Currently the build badge is broken and out of date - can we move this to GitHub actions? I've tested and it's passing, here's the preview with my repo url in the README:
![image](https://github.com/beanstalkd/beaneater/assets/6366639/f6513a3b-d92a-4a6a-b363-1362c3361d74)

Currently my repo has a broken badge as well, since I updated the url to beanstalkd/beaneater for this pull request.

I'm planning to use this gem a lot more and knowing its build is passing on my Ruby version would be very helpful (I'm currently on 3.1).  I did remove testing for Ruby 2.5, since it's been out of support for over 2 years, but I kept 2.6 in the workflow.