### PR TITLE
add frozen string literal comments.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in beaneater.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require 'rake/testtask'
 require 'yard'

--- a/beaneater.gemspec
+++ b/beaneater.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # -*- encoding: utf-8 -*-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/examples/demo.rb
+++ b/examples/demo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'term/ansicolor'
 class String; include Term::ANSIColor; end
 def step(msg); "\n[STEP] #{msg}...".yellow; end

--- a/lib/beaneater.rb
+++ b/lib/beaneater.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'thread' unless defined?(Mutex)
 
 %w(version configuration errors connection tube job stats).each do |f|

--- a/lib/beaneater/configuration.rb
+++ b/lib/beaneater/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   class Configuration
     attr_accessor :default_put_delay   # default delay value to put a job

--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 require 'socket'
 

--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -76,7 +76,7 @@ class Beaneater
         @mutex.synchronize do
           _raise_not_connected! unless connection
 
-          command = command.force_encoding('ASCII-8BIT') if command.respond_to?(:force_encoding)
+          command = command.dup.force_encoding('ASCII-8BIT') if command.respond_to?(:force_encoding)
           connection.write(command.to_s + "\r\n")
           res = connection.readline
           parse_response(command, res)

--- a/lib/beaneater/errors.rb
+++ b/lib/beaneater/errors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   # Raises when a beanstalkd instance is no longer accessible.
   class NotConnected < RuntimeError; end

--- a/lib/beaneater/job.rb
+++ b/lib/beaneater/job.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'beaneater/job/record'
 require 'beaneater/job/collection'

--- a/lib/beaneater/job/collection.rb
+++ b/lib/beaneater/job/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   # Exception to stop processing jobs during a `process!` loop.
   # Simply `raise AbortProcessingError` in any job process handler to stop the processing loop.

--- a/lib/beaneater/job/record.rb
+++ b/lib/beaneater/job/record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   # Represents job related commands.
   class Job

--- a/lib/beaneater/stats.rb
+++ b/lib/beaneater/stats.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'beaneater/stats/fast_struct'
 require 'beaneater/stats/stat_struct'
 

--- a/lib/beaneater/stats/fast_struct.rb
+++ b/lib/beaneater/stats/fast_struct.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   #
   # Borrowed from:

--- a/lib/beaneater/stats/stat_struct.rb
+++ b/lib/beaneater/stats/stat_struct.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   # Represents a stats hash with proper underscored keys
   class StatStruct < FasterOpenStruct

--- a/lib/beaneater/tube.rb
+++ b/lib/beaneater/tube.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'beaneater/tube/record'
 require 'beaneater/tube/collection'

--- a/lib/beaneater/tube/collection.rb
+++ b/lib/beaneater/tube/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   # Represents collection of tube related commands.
 

--- a/lib/beaneater/tube/record.rb
+++ b/lib/beaneater/tube/record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   # Beanstalk tube which contains jobs which can be inserted, reserved, et al.
   class Tube

--- a/lib/beaneater/version.rb
+++ b/lib/beaneater/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Beaneater
   # Current version of gem.
   VERSION = "1.1.3"

--- a/test/beaneater_test.rb
+++ b/test/beaneater_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../test_helper', __FILE__)
 
 describe "beanstalk-client" do

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -103,6 +103,7 @@ describe Beaneater::Connection do
       client = Beaneater.new('127.0.0.1:11300')
       client.tubes.watch! "another"
 
+      $called = false
       TCPSocket.prepend Module.new {
         def readline
           if !$called
@@ -115,6 +116,8 @@ describe Beaneater::Connection do
       }
 
       assert_equal %w[another], client.tubes.watched.map(&:name)
+    ensure
+      $called = nil
     end
   end # transmit
 

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/connection_test.rb
 
 require File.expand_path('../test_helper', __FILE__)

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/errors_test.rb
 
 require File.expand_path('../test_helper', __FILE__)

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -12,6 +12,7 @@ describe Beaneater::Job do
 
   describe "for #bury" do
     before do
+      @tube.clear
       @time = Time.now.to_i
       @tube.put "foo bury #{@time}", :pri => 5
     end

--- a/test/job_test.rb
+++ b/test/job_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/job_test.rb
 
 require File.expand_path('../test_helper', __FILE__)

--- a/test/jobs_test.rb
+++ b/test/jobs_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/jobs_test.rb
 
 require File.expand_path('../test_helper', __FILE__)

--- a/test/prompt_regexp_test.rb
+++ b/test/prompt_regexp_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/prompt_regexp_test.rb
 
 require File.expand_path('../test_helper', __FILE__)

--- a/test/stat_struct_test.rb
+++ b/test/stat_struct_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/stat_struct_test.rb
 
 require File.expand_path('../test_helper', __FILE__)

--- a/test/stats_test.rb
+++ b/test/stats_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/stats_test.rb
 
 require File.expand_path('../test_helper', __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["TEST"] = 'true'
 require 'rubygems'
 require 'coveralls'

--- a/test/tube_test.rb
+++ b/test/tube_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/tube_test.rb
 
 require File.expand_path('../test_helper', __FILE__)

--- a/test/tubes_test.rb
+++ b/test/tubes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # test/tubes_test.rb
 
 require File.expand_path('../test_helper', __FILE__)


### PR DESCRIPTION
Add frozen strings to stop warnings:

```bash
/.gem/ruby/3.4.7/gems/beaneater-1.1.3/lib/beaneater/connection.rb:77: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

Let me know if you need/want anything else! Thanks for your consideration.