### PR TITLE
Add support for TCP connection timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for Beaneater
 
+## Unreleased
+
+* Add `connect_timeout` (Ruby 3+), `resolv_timeout` (Ruby 3+), `read_timeout`, and `write_timeout` configuration options
+
 ## 1.1.4 (March 6 2026)
 
 * Add frozen string literal comments for Ruby 3.4 compatibility (@nearapogee)

--- a/README.md
+++ b/README.md
@@ -133,10 +133,16 @@ Beaneater.configure do |config|
   # config.job_parser          = lambda { |body| body }
   # config.job_serializer      = lambda { |body| body }
   # config.beanstalkd_url      = 'localhost:11300'
+  # config.connect_timeout     = nil
+  # config.resolv_timeout      = nil
+  # config.read_timeout        = nil
+  # config.write_timeout       = nil
 end
 ```
 
 The above options are all defaults, so only include a configuration block if you need to make changes.
+
+`connect_timeout` and `resolv_timeout` are passed through to `TCPSocket.new` on Ruby 3.0 and newer (ignored on Ruby < 3.0 for compatibility). `read_timeout` and `write_timeout` apply socket read and write timeouts via `setsockopt`.
 
 ### Connection
 

--- a/lib/beaneater/configuration.rb
+++ b/lib/beaneater/configuration.rb
@@ -8,6 +8,10 @@ class Beaneater
     attr_accessor :job_parser          # default job_parser to parse job body
     attr_accessor :job_serializer      # default serializer for job body
     attr_accessor :beanstalkd_url      # default beanstalkd url
+    attr_accessor :connect_timeout     # TCP connect timeout in seconds
+    attr_accessor :resolv_timeout      # DNS resolve timeout in seconds
+    attr_accessor :read_timeout        # socket read timeout in seconds
+    attr_accessor :write_timeout       # socket write timeout in seconds
 
     def initialize
       @default_put_delay   = 0
@@ -16,6 +20,10 @@ class Beaneater
       @job_parser          = lambda { |body| body }
       @job_serializer      = lambda { |body| body }
       @beanstalkd_url      = nil
+      @connect_timeout     = nil
+      @resolv_timeout      = nil
+      @read_timeout        = nil
+      @write_timeout       = nil
     end
   end # Configuration
 end # Beaneater

--- a/lib/beaneater/connection.rb
+++ b/lib/beaneater/connection.rb
@@ -129,7 +129,18 @@ class Beaneater
       match = address.split(':')
       @host, @port = match[0], Integer(match[1] || DEFAULT_PORT)
 
-      @connection = TCPSocket.new @host, @port
+      tcp_opts = { connect_timeout: config.connect_timeout, resolv_timeout: config.resolv_timeout }.compact
+
+      socket = if RUBY_VERSION.to_i >= 3 && tcp_opts.any?
+        TCPSocket.new(@host, @port, **tcp_opts)
+      else
+        TCPSocket.new(@host, @port)
+      end
+
+      socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVTIMEO, [config.read_timeout, 0].pack('l_l_')) if config.read_timeout
+      socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_SNDTIMEO, [config.write_timeout, 0].pack('l_l_')) if config.write_timeout
+
+      @connection = socket
     end
 
     # Parses the response and returns the useful beanstalk response.

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -41,6 +41,61 @@ describe Beaneater::Connection do
     end
   end # new
 
+  describe 'for timeout configuration' do
+    after do
+      Beaneater.configure do |config|
+        config.connect_timeout = nil
+        config.resolv_timeout  = nil
+        config.read_timeout    = nil
+        config.write_timeout   = nil
+      end
+    end
+
+    it "should pass connect_timeout and resolv_timeout to TCPSocket.new on Ruby >= 3.0" do
+      skip("connect_timeout/resolv_timeout kwargs require Ruby >= 3.0") if RUBY_VERSION.to_i < 3
+
+      Beaneater.configure do |config|
+        config.connect_timeout = 2
+        config.resolv_timeout  = 2
+      end
+
+      real_socket = TCPSocket.new('localhost', 11300)
+      TCPSocket.expects(:new).with('localhost', 11300, connect_timeout: 2, resolv_timeout: 2).returns(real_socket)
+
+      bc = Beaneater::Connection.new('localhost')
+      assert_kind_of TCPSocket, bc.connection
+    end
+
+    it "should ignore connect_timeout and resolv_timeout on Ruby < 3.0" do
+      skip("connect_timeout/resolv_timeout kwargs are supported on Ruby >= 3.0") if RUBY_VERSION.to_i >= 3
+
+      Beaneater.configure do |config|
+        config.connect_timeout = 2
+        config.resolv_timeout  = 4
+      end
+
+      real_socket = TCPSocket.new('localhost', 11300)
+      TCPSocket.expects(:new).with('localhost', 11300).returns(real_socket)
+
+      bc = Beaneater::Connection.new('localhost')
+      assert_same real_socket, bc.connection
+    end
+
+    it "should set SO_RCVTIMEO and SO_SNDTIMEO when read/write timeouts are configured" do
+      Beaneater.configure do |config|
+        config.read_timeout  = 3
+        config.write_timeout = 5
+      end
+
+      bc = Beaneater::Connection.new('localhost')
+      rcv = bc.connection.getsockopt(Socket::SOL_SOCKET, Socket::SO_RCVTIMEO).unpack('l_l_')[0]
+      snd = bc.connection.getsockopt(Socket::SOL_SOCKET, Socket::SO_SNDTIMEO).unpack('l_l_')[0]
+      assert_equal 3, rcv
+      assert_equal 5, snd
+    end
+
+  end # timeout configuration
+
   describe 'for #transmit' do
     before do
       @host = 'localhost'


### PR DESCRIPTION
This PR will add configurable TCP connection timeout options for Beaneater. Please note that for compatibility reasons some of these are ignored on Ruby < 3.0.

All tests are passing locally.

I have been using this code (monkey patched) to build a beanstalkd monitoring probe, but I am sure there are other use cases for configurable TCP timeouts.
